### PR TITLE
Change tag colors to better match UI priority

### DIFF
--- a/css/tags.css
+++ b/css/tags.css
@@ -11,8 +11,8 @@
 
 .tags .tag {
 	padding: 0px 4px;
-	background: #0089e0;
-	color: #fff;
+	background: #e6e6e6;
+	color: #666;
 	border-radius: 2px;
 }
 


### PR DESCRIPTION
From a UX perspective, the tags, like the file extension, are secondary, not primary information for the user.

Accordingly, I propose that just like the file extension, that the tags use a more monochrome, lighter tone set of colors so as not to distract the user from more primary information.